### PR TITLE
Enforce checkbox removal in pr template

### DIFF
--- a/.github/workflows/check-pr-description.yaml
+++ b/.github/workflows/check-pr-description.yaml
@@ -1,0 +1,18 @@
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-pr-template:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR description
+        id: check_pr_description
+        run: |
+            PR_DESCRIPTION='${{ github.event.pull_request.body }}'
+            TYPE_OF_CHANGE_SECTION=$(echo "$PR_DESCRIPTION" | sed -n '/## Type of change/,/## Checklist:/p')
+            if echo "$TYPE_OF_CHANGE_SECTION" | grep -q "\[ \]"; then
+              echo "Unselected checkboxes found in the 'Type of change' section of the pull request description. Please delete unselected items in this section."
+              exit 1
+            fi
+

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,17 +1,22 @@
 ## Purpose of this PR
 
+> **NOTE** Make sure to select the items relevant to your PR by placing an "x" in the brackets. *Delete* the parts that are left empty. This way the progress tracker accurately reflects the status of the PR. Leave *unfinished* elements in the checklist unchecked so we know how far along you are
 
 ## Type of change
 
-(Make sure to delete from the Type-of-change list the items not relevant to your PR)
+### Parts concerned:
+- [ ] Code
+- [ ] Documentation
+- [ ] Input Data
+- [ ] Other
 
-- [ ] Bug fix 
+### Impact:
+- [ ] Bug fix
 - [ ] Refactoring
-- [ ] New feature 
+- [ ] New feature
 - [ ] Minor change (default scenarios show only small differences)
 - [ ] Fundamental change
 - [ ] This change requires a documentation update
-
 
 ## Checklist:
 
@@ -29,4 +34,3 @@
 
 * Runs with these changes are here:
 * Comparison of results (what changes by this PR?): 
-

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -7,8 +7,9 @@
 ### Parts concerned:
 - [ ] Code
 - [ ] Documentation
-- [ ] Input Data
-- [ ] Other
+- [ ] Input data
+- [ ] CI/CD
+- [ ] Other (please give a description)
 
 ### Impact:
 - [ ] Bug fix


### PR DESCRIPTION
## Purpose of this PR

> **NOTE** Make sure to select the items relevant to your PR by placing an "x" in the brackets. *Delete* the parts that are left empty. This way the progress tracker accurately reflects the status of the PR. Leave *unfinished* elements in the checklist unchecked so we know how far along you are

Split Impact section in the `pull_request_template.md` into two separate sections. First section "Parts concerned" characterizes which part of REMIND has been modified, second part the type of change as-is.

In order to ensure the progress tracker of each PR is representative of the actual state of the PR RSE wants to enforce that users delete the unselected checkboxes in the "Type of change" section. The checklist itself counts towards the state of the PR and is left unchanged. Users that forgot to delete checkboxes will ~~receive an automated comment on their PR~~ see the github action fail

## Type of change

### Parts concerned:
- [x] CI/CD

### Impact:
- [x] New feature

## Checklist:

- [ ] My code follows the [coding etiquette](https://github.com/remindmodel/remind/blob/develop/main.gms#L80)
- [ ] I performed a self-review of my own code
- [ ] I explained my changes within the PR, particularly in hard-to-understand areas
- [ ] I checked that the [in-code documentation](https://github.com/remindmodel/remind/blob/develop/main.gms#L120) is up-to-date
- [ ] I adjusted the reporting in [`remind2`](https://github.com/pik-piam/remind2) where it was needed
- [ ] I adjusted `forbiddenColumnNames` in [readCheckScenarioConfig.R](https://github.com/remindmodel/remind/blob/develop/scripts/start/readCheckScenarioConfig.R) in case the PR leads to deprecated switches
- [ ] I checked the `log.txt` file of my runs for newly introduced summation, fixing or variable name errors
- [ ] All automated model tests pass, executed after my final commit (`FAIL 0` in the output of `make test`)
- [ ] The changelog `CHANGELOG.md` [has been updated correctly](https://gitlab.pik-potsdam.de/rse/rsewiki/-/wikis/Standards-for-Writing-a-Changelog)

## Further information (optional):

* Runs with these changes are here:
* Comparison of results (what changes by this PR?): 
